### PR TITLE
Fix: Rename repository to gh-upskill for GitHub CLI extension compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Quickly install Claude/Agent skills from another repository. Works standalone an
 ## Install
 
 - Standalone
-  - macOS/Linux: `curl -fsSL https://raw.githubusercontent.com/trieloff/upskill/main/install.sh | bash`
-  - Custom prefix: `curl -fsSL https://raw.githubusercontent.com/trieloff/upskill/main/install.sh | bash -s -- --prefix ~/.local`
+  - macOS/Linux: `curl -fsSL https://raw.githubusercontent.com/trieloff/gh-upskill/main/install.sh | bash`
+  - Custom prefix: `curl -fsSL https://raw.githubusercontent.com/trieloff/gh-upskill/main/install.sh | bash -s -- --prefix ~/.local`
 
 - GitHub CLI extension
-  - `gh extension install trieloff/upskill`
+  - `gh extension install trieloff/gh-upskill`
   - Then run via `gh upskill ...` (or use `upskill` directly)
 
 ## Usage

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -Eeo pipefail
 IFS=$'\n\t'
 
-REPO="trieloff/upskill"
+REPO="trieloff/gh-upskill"
 RAW_ROOT="https://raw.githubusercontent.com/${REPO}/main"
 
 usage() {


### PR DESCRIPTION
## Summary
- Renamed repository from `trieloff/upskill` to `trieloff/gh-upskill` to comply with GitHub CLI extension naming requirements
- Updated all references in README.md and install.sh to use the new repository name
- GitHub CLI requires extension repositories to start with `gh-` prefix

## Test plan
- [ ] Verify `gh extension install trieloff/gh-upskill` works without errors
- [ ] Verify standalone installation with updated URLs works
- [ ] Confirm `gh upskill` command functions correctly after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)