### PR TITLE
Modernize skill destinations and remove AGENTS.md polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,15 @@ npx skills add https://github.com/adobe/skills/tree/main/skills/aem/edge-deliver
 
 ### Install skills globally (personal skills)
 
-Use the `-g` or `--global` flag to install skills to `~/.skills` instead of the project's `.skills` directory:
+Use the `-g` or `--global` flag to install skills to `~/.agents/skills` instead of the project's `.agents/skills/` directory:
 
 ```
 upskill -g anthropics/skills --skill pdf --skill xlsx
 ```
 
 When installing globally:
-- Skills are installed to `~/.skills`
-- `.agents/discover-skills` and `AGENTS.md` are not modified (since these are project-specific)
+- Skills are installed to `~/.agents/skills`
+- If `~/.claude/` exists, skills are also installed to `~/.claude/skills/` (see [Claude Code auto-detection](#claude-code-auto-detection))
 
 ### Install to custom destination
 
@@ -75,39 +75,36 @@ Use `--dest-path` to install skills to a custom location:
 upskill anthropics/skills --skill pdf --dest-path .claude/skills
 ```
 
-This is useful for compatibility with tools that expect skills in different locations (e.g., `.claude/skills`).
+This is useful for compatibility with tools that expect skills in different locations. Note that `--dest-path` disables [Claude Code auto-detection](#claude-code-auto-detection).
 
 ### Options
 
 | Option | Description |
 |--------|-------------|
-| `-g, --global` | Install to `~/.skills` (personal skills) |
+| `-g, --global` | Install to `~/.agents/skills` (personal skills) |
 | `-b, --branch <ref>` | Branch, tag, or commit to clone |
 | `-p, --path <subfolder>` | Only discover skills under this subfolder |
 | `--dest-path <path>` | Custom destination path (overrides `-g`) |
 | `--list` | List available skills without installing |
 | `--skill <name>` | Install specific skill(s) (repeatable) |
 | `--all` | Install all discovered skills |
-| `-i` | Add `.skills/` to `.gitignore` |
+| `-i` | Add `.agents/skills/` to `.gitignore` |
 | `-q, --quiet` | Reduce output |
 
 ## How it works
 
 1. Clones the source repository to a temp directory
 2. Scans for all `**/SKILL.md` files (per agentskills.io spec)
-3. Copies selected skill directories to `.skills/` (or custom destination)
-4. Creates `.agents/discover-skills` helper script
-5. Updates `AGENTS.md` with skills section (if source has one)
+3. Copies selected skill directories to `.agents/skills/` (or custom destination)
 
-## Discover installed skills
+### Claude Code auto-detection
 
-After installing, list available skills in your project:
+When `--dest-path` is **not** used, upskill automatically detects Claude Code environments and dual-installs skills:
 
-```
-./.agents/discover-skills
-```
+- **Local installs:** if a `.claude/` directory or `CLAUDE.md` file exists in the project, skills are also installed to `.claude/skills/`
+- **Global installs (`-g`):** if `~/.claude/` exists, skills are also installed to `~/.claude/skills/`
 
-This scans both project skills (`.skills/`) and personal skills (`~/.skills/`), plus legacy `.claude/skills` locations for backwards compatibility.
+Using `--dest-path` disables this auto-detection — skills are only installed to the specified path.
 
 ## Development
 

--- a/tests/test-upskill.sh
+++ b/tests/test-upskill.sh
@@ -17,76 +17,93 @@ trap cleanup EXIT
 
 pushd "$TMP" >/dev/null
 
-echo "Running upskill (first run) ..."
-# Always scans for **/SKILL.md per agentskills.io spec
+# --- Test 1: Default install to .agents/skills/ ---
+echo "Test 1: Default install to .agents/skills/ ..."
 "$ROOT_DIR/upskill" adobe/helix-website -b main --all
 
-test -d .skills || { echo "FAIL: .skills missing"; exit 1; }
-count_skills=$(find .skills -name 'SKILL.md' -type f | wc -l | tr -d ' ')
-if [[ "$count_skills" -le 0 ]]; then
-  echo "FAIL: No SKILL.md files copied"
-  exit 1
-fi
+test -d .agents/skills || { echo "FAIL: .agents/skills missing"; exit 1; }
+count_skills=$(find .agents/skills -name 'SKILL.md' -type f | wc -l | tr -d ' ')
+[[ "$count_skills" -gt 0 ]] || { echo "FAIL: No SKILL.md files copied"; exit 1; }
+echo "  Installed $count_skills skill(s) to .agents/skills/"
 
-test -x .agents/discover-skills || { echo "FAIL: .agents/discover-skills not executable"; exit 1; }
+# --- Test 2: No AGENTS.md created ---
+echo "Test 2: No AGENTS.md created ..."
+test ! -f AGENTS.md || { echo "FAIL: AGENTS.md should not be created"; exit 1; }
 
-echo "Checking AGENTS.md markers ..."
-marker_start='<!-- upskill:skills:start -->'
-marker_end='<!-- upskill:skills:end -->'
-grep -qF "$marker_start" AGENTS.md || { echo "FAIL: start marker missing"; exit 1; }
-grep -qF "$marker_end" AGENTS.md || { echo "FAIL: end marker missing"; exit 1; }
+# --- Test 3: No .agents/discover-skills created ---
+echo "Test 3: No .agents/discover-skills created ..."
+test ! -f .agents/discover-skills || { echo "FAIL: .agents/discover-skills should not be created"; exit 1; }
 
-count_markers=$(grep -cF "$marker_start" AGENTS.md)
-[[ "$count_markers" == "1" ]] || { echo "FAIL: duplicate start markers on first run"; exit 1; }
+# --- Test 4: Without .claude/ dir, only .agents/skills/ exists (no .claude/skills/) ---
+echo "Test 4: Without .claude/, no .claude/skills/ ..."
+test ! -d .claude/skills || { echo "FAIL: .claude/skills/ should not exist without .claude/ dir"; exit 1; }
 
-echo "Running upskill (second run) ..."
+# --- Test 5: Claude Code auto-detection ---
+echo "Test 5: Claude Code auto-detection ..."
+rm -rf .agents/skills
+mkdir -p .claude
 "$ROOT_DIR/upskill" adobe/helix-website -b main --all
 
-count_markers2=$(grep -cF "$marker_start" AGENTS.md)
-[[ "$count_markers2" == "1" ]] || { echo "FAIL: duplicate start markers after second run"; exit 1; }
+test -d .agents/skills || { echo "FAIL: .agents/skills missing with Claude detect"; exit 1; }
+test -d .claude/skills || { echo "FAIL: .claude/skills missing when .claude/ exists"; exit 1; }
+count_agents=$(find .agents/skills -name 'SKILL.md' -type f | wc -l | tr -d ' ')
+count_claude=$(find .claude/skills -name 'SKILL.md' -type f | wc -l | tr -d ' ')
+[[ "$count_agents" -gt 0 ]] || { echo "FAIL: No skills in .agents/skills/"; exit 1; }
+[[ "$count_claude" -gt 0 ]] || { echo "FAIL: No skills in .claude/skills/"; exit 1; }
+echo "  Skills in .agents/skills/: $count_agents, .claude/skills/: $count_claude"
 
-echo "Running discover-skills ..."
-out="$(.agents/discover-skills | sed -n '1,40p')"
-echo "$out" | grep -q "Available Skills:" || { echo "FAIL: discover-skills header missing"; exit 1; }
-echo "$out" | grep -q -- "---" || { echo "FAIL: discover-skills separator missing"; exit 1; }
-
-# Test gitignore insertion with -i
-echo "Running upskill with -i ..."
-"$ROOT_DIR/upskill" -i adobe/helix-website -b main --all
-
-test -f .gitignore || { echo "FAIL: .gitignore not created"; exit 1; }
-grep -qF ".skills/" .gitignore || { echo "FAIL: .gitignore missing skills entry"; exit 1; }
-grep -qF ".agents/discover-skills" .gitignore || { echo "FAIL: .gitignore missing discover entry"; exit 1; }
-
-# Ensure idempotent block
-start_marker="# upskill:gitignore:start"
-[[ $(grep -cF "$start_marker" .gitignore) == "1" ]] || { echo "FAIL: duplicate gitignore block after first -i"; exit 1; }
-"$ROOT_DIR/upskill" -i adobe/helix-website -b main --all
-[[ $(grep -cF "$start_marker" .gitignore) == "1" ]] || { echo "FAIL: duplicate gitignore block after second -i"; exit 1; }
-
-# Test --dest-path flag
-echo "Testing --dest-path flag ..."
+# --- Test 6: --dest-path disables Claude auto-detection ---
+echo "Test 6: --dest-path disables Claude auto-detection ..."
+rm -rf custom-skills .claude/skills
+# .claude/ dir still exists from previous test
 "$ROOT_DIR/upskill" adobe/helix-website -b main --all --dest-path custom-skills
 test -d custom-skills || { echo "FAIL: custom-skills directory missing"; exit 1; }
 count_custom=$(find custom-skills -name 'SKILL.md' -type f | wc -l | tr -d ' ')
 [[ "$count_custom" -gt 0 ]] || { echo "FAIL: No skills in custom destination"; exit 1; }
+test ! -d .claude/skills || { echo "FAIL: --dest-path should disable Claude auto-detect"; exit 1; }
 
-# Test --path flag (subfolder filtering)
-echo "Testing --path flag ..."
+# --- Test 7: --path subfolder filtering ---
+echo "Test 7: --path subfolder filtering ..."
 "$ROOT_DIR/upskill" adobe/skills -b main --path skills/aem/edge-delivery-services --all --dest-path path-filtered-skills
 test -d path-filtered-skills || { echo "FAIL: path-filtered-skills directory missing"; exit 1; }
 count_path=$(find path-filtered-skills -name 'SKILL.md' -type f | wc -l | tr -d ' ')
 [[ "$count_path" -gt 0 ]] || { echo "FAIL: No skills found with --path filter"; exit 1; }
-echo "Found $count_path skill(s) with --path filter"
+echo "  Found $count_path skill(s) with --path filter"
 
-# Test --path with invalid path
-echo "Testing --path with invalid path ..."
+# --- Test 8: -i adds correct entries to .gitignore ---
+echo "Test 8: -i adds correct entries to .gitignore ..."
+rm -f .gitignore
+# .claude/ dir still exists → should add both entries
+"$ROOT_DIR/upskill" -i adobe/helix-website -b main --all
+test -f .gitignore || { echo "FAIL: .gitignore not created"; exit 1; }
+grep -qF ".agents/skills/" .gitignore || { echo "FAIL: .gitignore missing .agents/skills/ entry"; exit 1; }
+grep -qF ".claude/skills/" .gitignore || { echo "FAIL: .gitignore missing .claude/skills/ entry when Claude detected"; exit 1; }
+
+# --- Test 9: Gitignore is idempotent ---
+echo "Test 9: Gitignore idempotency ..."
+agents_count_before=$(grep -cF ".agents/skills/" .gitignore)
+claude_count_before=$(grep -cF ".claude/skills/" .gitignore)
+"$ROOT_DIR/upskill" -i adobe/helix-website -b main --all
+agents_count_after=$(grep -cF ".agents/skills/" .gitignore)
+claude_count_after=$(grep -cF ".claude/skills/" .gitignore)
+[[ "$agents_count_before" == "$agents_count_after" ]] || { echo "FAIL: .agents/skills/ duplicated in .gitignore"; exit 1; }
+[[ "$claude_count_before" == "$claude_count_after" ]] || { echo "FAIL: .claude/skills/ duplicated in .gitignore"; exit 1; }
+
+# --- Test 10: --list still works ---
+echo "Test 10: --list ..."
+list_output=$("$ROOT_DIR/upskill" adobe/helix-website -b main --list 2>&1)
+echo "$list_output" | grep -q "Available skills" || { echo "FAIL: --list output missing header"; exit 1; }
+echo "$list_output" | grep -q "Found" || { echo "FAIL: --list output missing count"; exit 1; }
+
+# --- Test 11: --path with invalid path ---
+echo "Test 11: --path with invalid path ..."
 if "$ROOT_DIR/upskill" adobe/skills -b main --path nonexistent/path --all --dest-path bad-path 2>/dev/null; then
   echo "FAIL: --path with invalid path should have failed"
   exit 1
 fi
-echo "Correctly rejected invalid --path"
+echo "  Correctly rejected invalid --path"
 
-echo "OK"
+echo ""
+echo "ALL TESTS PASSED"
 
 popd >/dev/null

--- a/upskill
+++ b/upskill
@@ -281,12 +281,14 @@ main() {
 
   # Install skills
   local skill_count=0
+  local -a installed_skill_names=()
 
   if [[ -n "$install_all" ]]; then
     log "Installing all $total_count skills..."
     while IFS='|' read -r name path description; do
       copy_skill "$path" "$dest_skills_dir"
       skill_count=$((skill_count + 1))
+      installed_skill_names+=("$(basename "$(dirname "$path")")")
     done <"$tmpfile"
   elif [[ ${#selected_skills[@]} -gt 0 ]]; then
     log "Installing ${#selected_skills[@]} selected skill(s)..."
@@ -296,6 +298,7 @@ main() {
         if [[ "$name" == "$skill_name" ]]; then
           copy_skill "$path" "$dest_skills_dir"
           skill_count=$((skill_count + 1))
+          installed_skill_names+=("$(basename "$(dirname "$path")")")
           found=1
           break
         fi
@@ -335,18 +338,15 @@ main() {
       log "Also installing to $claude_dest (Claude Code detected)"
       mkdir -p "$claude_dest"
       # Copy each installed skill from the primary destination to the Claude destination
-      for skill_subdir in "$dest_skills_dir"/*/; do
-        [[ -d "$skill_subdir" ]] || continue
-        local sname
-        sname=$(basename "$skill_subdir")
+      for sname in "${installed_skill_names[@]}"; do
         mkdir -p "$claude_dest/$sname"
-        copy_tree "$skill_subdir" "$claude_dest/$sname"
+        copy_tree "$dest_skills_dir/$sname" "$claude_dest/$sname"
       done
 
       # If -i is set and this is a local install, add .claude/skills/ to .gitignore
       if [[ -n "${add_to_gitignore:-}" && -z "$global_install" ]]; then
         if ! grep -qxF '.claude/skills/' .gitignore 2>/dev/null; then
-          printf '.claude/skills/\n' >>.gitignore
+          printf '\n.claude/skills/\n' >>.gitignore
           log "Added .claude/skills/ to .gitignore"
         fi
       fi
@@ -355,9 +355,12 @@ main() {
 
   # Optionally add skills directory to .gitignore
   if [[ -n "$add_to_gitignore" && -z "$global_install" ]]; then
-    if ! grep -qxF '.agents/skills/' .gitignore 2>/dev/null; then
-      printf '\n# upskill\n.agents/skills/\n' >>.gitignore
-      log "Added .agents/skills/ to .gitignore"
+    local gitignore_entry="${dest_skills_dir%/}/"
+    if [[ "$gitignore_entry" != /* ]]; then
+      if ! grep -qxF "$gitignore_entry" .gitignore 2>/dev/null; then
+        printf '\n# upskill\n%s\n' "$gitignore_entry" >>.gitignore
+        log "Added $gitignore_entry to .gitignore"
+      fi
     fi
   fi
 

--- a/upskill
+++ b/upskill
@@ -3,7 +3,7 @@ set -Eeo pipefail
 IFS=$'\n\t'
 
 PROGRAM_NAME="upskill"
-VERSION="0.1.0"
+VERSION="0.2.0"
 
 usage() {
   cat <<USAGE

--- a/upskill
+++ b/upskill
@@ -18,13 +18,13 @@ Examples:
   ${PROGRAM_NAME} anthropics/skills --list
   ${PROGRAM_NAME} anthropics/skills --skill pdf --skill xlsx
   ${PROGRAM_NAME} anthropics/skills --all
-  ${PROGRAM_NAME} -g anthropics/skills --skill pdf  # Install to ~/.skills
+  ${PROGRAM_NAME} -g anthropics/skills --skill pdf  # Install to ~/.agents/skills
   ${PROGRAM_NAME} anthropics/skills --dest-path .claude/skills  # Custom destination
   ${PROGRAM_NAME} adobe/skills --path skills/aem/edge-delivery-services --all  # Subfolder
 
 Options:
   -i                        Add created files to .gitignore
-  -g, --global              Install skills to ~/.skills (personal skills)
+  -g, --global              Install skills to ~/.agents/skills (personal skills)
   -b, --branch <branch>     Branch, tag, or commit to clone (default: repo default)
   -p, --path <subfolder>    Only discover skills under this subfolder
   --dest-path <path>        Custom destination path for skills (overrides -g)
@@ -61,148 +61,6 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
-
-insert_or_replace_block() {
-  # $1: target file
-  # $2: start marker
-  # $3: end marker
-  # stdin: block content (without markers)
-  local file="$1"; shift
-  local start_marker="$1"; shift
-  local end_marker="$1"; shift
-
-  local block tmp blockfile
-  block=$(cat)
-
-  if [[ ! -f "$file" ]]; then
-    printf '%s\n\n%s\n%s\n%s\n' "# AGENTS.md" "$start_marker" "$block" "$end_marker" >"$file"
-    return 0
-  fi
-
-  if grep -qF "$start_marker" "$file" && grep -qF "$end_marker" "$file"; then
-    tmp=$(mktemp)
-    blockfile=$(mktemp)
-    printf '%s\n' "$block" >"$blockfile"
-    awk -v start="$start_marker" -v end="$end_marker" -v fblock="$blockfile" '
-      BEGIN{skip=0}
-      $0 ~ start {
-        print $0
-        # print replacement content
-        cmd = "cat " fblock
-        while ((cmd | getline line) > 0) print line
-        close(cmd)
-        skip=1
-        next
-      }
-      $0 ~ end && skip==1 { print $0; skip=0; next }
-      skip==1 { next }
-      { print $0 }
-    ' "$file" >"$tmp"
-    mv "$tmp" "$file"
-    rm -f "$blockfile"
-  else
-    {
-      printf '\n%s\n' "$start_marker"
-      printf '%s\n' "$block"
-      printf '%s\n' "$end_marker"
-    } >>"$file"
-  fi
-}
-
-generate_discover_skills() {
-  cat <<'SCRIPT'
-#!/usr/bin/env bash
-set -Eo pipefail
-IFS=$'\n\t'
-
-# Discover available skills in both project and global directories
-# Usage: .agents/discover-skills
-
-PROJECT_SKILLS_DIR=".skills"
-PROJECT_SKILLS_DIR_LEGACY=".claude/skills"
-GLOBAL_SKILLS_DIR="$HOME/.skills"
-GLOBAL_SKILLS_DIR_LEGACY="$HOME/.claude/skills"
-
-process_skills_directory() {
-  local skills_dir="$1"
-  local location_label="$2"
-
-  if [[ ! -d "$skills_dir" ]]; then
-    return 0
-  fi
-
-  local count=0
-  # Count skills first
-  while IFS= read -r -d '' skill_file; do
-    count=$((count + 1))
-  done < <(find "$skills_dir" -type f -name 'SKILL.md' -print0)
-
-  if [[ $count -eq 0 ]]; then
-    return 0
-  fi
-
-  echo "$location_label ($count skill(s)):"
-  # Generate underline matching label length
-  local len=${#location_label}
-  if [[ $len -gt 0 ]]; then
-    local underline=""
-    for ((i=0; i<len; i++)); do
-      underline+="="
-    done
-    echo "$underline"
-  fi
-  echo ""
-
-  # Iterate SKILL.md files robustly (handles spaces)
-  while IFS= read -r -d '' skill_file; do
-    skill_dir=$(dirname "$skill_file")
-    skill_name=$(basename "$skill_dir")
-
-    # Check for YAML frontmatter
-    if head -n 1 "$skill_file" | grep -q "^---$"; then
-      # Extract lines between first pair of --- delimiters
-      frontmatter=$(awk 'BEGIN{inside=0; c=0} /^---$/ {inside=!inside; if(++c==3) exit} inside==1 {print}' "$skill_file")
-      name=$(printf '%s\n' "$frontmatter" | awk -F': *' '/^name:/ {sub(/^name: */,"",$0); print substr($0, index($0,$2))}' 2>/dev/null)
-      description=$(printf '%s\n' "$frontmatter" | awk -F': *' '/^description:/ {sub(/^description: */,"",$0); print substr($0, index($0,$2))}' 2>/dev/null)
-
-      echo "Skill: ${name:-$skill_name}"
-      echo "Path: $skill_file"
-      if [[ -n "$description" ]]; then
-        echo "Description: $description"
-      fi
-    else
-      echo "Skill: $skill_name"
-      echo "Path: $skill_file"
-      echo "Description:"
-      head -n 5 "$skill_file"
-    fi
-
-    echo ""
-    echo "---"
-    echo ""
-  done < <(find "$skills_dir" -type f -name 'SKILL.md' -print0)
-}
-
-echo "Available Skills:"
-echo "=================="
-echo ""
-
-# Check project skills (new location first, then legacy)
-process_skills_directory "$PROJECT_SKILLS_DIR" "Project Skills (.skills)"
-process_skills_directory "$PROJECT_SKILLS_DIR_LEGACY" "Project Skills (.claude/skills - legacy)"
-
-# Check global skills (new location first, then legacy)
-process_skills_directory "$GLOBAL_SKILLS_DIR" "Personal Skills (~/.skills)"
-process_skills_directory "$GLOBAL_SKILLS_DIR_LEGACY" "Personal Skills (~/.claude/skills - legacy)"
-
-# If no skills found at all
-if [[ ! -d "$PROJECT_SKILLS_DIR" && ! -d "$PROJECT_SKILLS_DIR_LEGACY" && ! -d "$GLOBAL_SKILLS_DIR" && ! -d "$GLOBAL_SKILLS_DIR_LEGACY" ]]; then
-  echo "No skills directories found."
-  echo "- Project skills: $PROJECT_SKILLS_DIR (or $PROJECT_SKILLS_DIR_LEGACY)"
-  echo "- Personal skills: $GLOBAL_SKILLS_DIR (or $GLOBAL_SKILLS_DIR_LEGACY)"
-fi
-SCRIPT
-}
 
 copy_tree() {
   # $1: src dir, $2: dest dir
@@ -408,16 +266,16 @@ main() {
     exit 0
   fi
 
-  # Determine destination: --dest-path > --global > default (.skills)
+  # Determine destination: --dest-path > --global > default (.agents/skills)
   local dest_skills_dir
   if [[ -n "$dest_path" ]]; then
     dest_skills_dir="$dest_path"
     log "Installing skills to custom path: $dest_skills_dir"
   elif [[ -n "$global_install" ]]; then
-    dest_skills_dir="$HOME/.skills"
+    dest_skills_dir="$HOME/.agents/skills"
     log "Installing skills globally to $dest_skills_dir"
   else
-    dest_skills_dir=".skills"
+    dest_skills_dir=".agents/skills"
   fi
   mkdir -p "$dest_skills_dir"
 
@@ -458,48 +316,48 @@ main() {
   rm -f "$tmpfile"
   log "Installed $skill_count skill(s)"
 
-  # For local installs, write .agents/discover-skills and update AGENTS.md
-  if [[ -z "$global_install" ]]; then
-    # Write .agents/discover-skills
-    mkdir -p .agents
-    local discover
-    discover=".agents/discover-skills"
-    log "Updating $discover ..."
-    generate_discover_skills >"$discover"
-    chmod +x "$discover"
-
-    # Extract Skills section from source AGENTS.md
-    local src_agents
-    src_agents="$clone_dir/AGENTS.md"
-    if [[ -f "$src_agents" ]]; then
-      log "Updating AGENTS.md skills section ..."
-      local block
-      block=$(awk '/^## Skills/{flag=1; print; next} /^## / && flag{exit} flag{print}' "$src_agents")
-      if [[ -z "$block" ]]; then
-        log "Warning: could not extract Skills section from $src_agents"
-      else
-        local start_marker end_marker
-        start_marker='<!-- upskill:skills:start -->'
-        end_marker='<!-- upskill:skills:end -->'
-        insert_or_replace_block "AGENTS.md" "$start_marker" "$end_marker" <<<"$block"
+  # Auto-detect Claude Code and dual-install (only when --dest-path is NOT used)
+  if [[ -z "$dest_path" ]]; then
+    local claude_dest=""
+    if [[ -n "$global_install" ]]; then
+      # Global: check for ~/.claude/
+      if [[ -d "$HOME/.claude" ]]; then
+        claude_dest="$HOME/.claude/skills"
       fi
     else
-      log "Warning: AGENTS.md not found in source repo, skipping skills section"
+      # Local: check for .claude/ directory or CLAUDE.md file
+      if [[ -d ".claude" || -f "CLAUDE.md" ]]; then
+        claude_dest=".claude/skills"
+      fi
     fi
 
-    # Optionally append ignore rules
-    if [[ -n "$add_to_gitignore" ]]; then
-      local start_marker end_marker
-      start_marker="# upskill:gitignore:start"
-      end_marker="# upskill:gitignore:end"
-      local block
-      block=$(cat <<'EOB'
-.skills/
-.agents/discover-skills
-EOB
-)
-      insert_or_replace_block ".gitignore" "$start_marker" "$end_marker" <<<"$block"
-      log "Updated .gitignore with upskill block"
+    if [[ -n "$claude_dest" ]]; then
+      log "Also installing to $claude_dest (Claude Code detected)"
+      mkdir -p "$claude_dest"
+      # Copy each installed skill from the primary destination to the Claude destination
+      for skill_subdir in "$dest_skills_dir"/*/; do
+        [[ -d "$skill_subdir" ]] || continue
+        local sname
+        sname=$(basename "$skill_subdir")
+        mkdir -p "$claude_dest/$sname"
+        copy_tree "$skill_subdir" "$claude_dest/$sname"
+      done
+
+      # If -i is set and this is a local install, add .claude/skills/ to .gitignore
+      if [[ -n "${add_to_gitignore:-}" && -z "$global_install" ]]; then
+        if ! grep -qxF '.claude/skills/' .gitignore 2>/dev/null; then
+          printf '.claude/skills/\n' >>.gitignore
+          log "Added .claude/skills/ to .gitignore"
+        fi
+      fi
+    fi
+  fi
+
+  # Optionally add skills directory to .gitignore
+  if [[ -n "$add_to_gitignore" && -z "$global_install" ]]; then
+    if ! grep -qxF '.agents/skills/' .gitignore 2>/dev/null; then
+      printf '\n# upskill\n.agents/skills/\n' >>.gitignore
+      log "Added .agents/skills/ to .gitignore"
     fi
   fi
 


### PR DESCRIPTION
## Summary

Modernizes upskill to align with the [agentskills.io](https://agentskills.io) cross-client standard and removes obsolete polyfill code.

### Changes

- **Default destination** changed from `.skills/` → `.agents/skills/` (local) and `~/.skills/` → `~/.agents/skills/` (global)
- **Claude Code auto-detection**: when `.claude/` or `CLAUDE.md` is present, skills are also installed to `.claude/skills/` — because Claude Code doesn't scan `.agents/skills/`
- **Removed AGENTS.md polyfill**: `insert_or_replace_block`, `generate_discover_skills`, and the post-install block that created `AGENTS.md` and `.agents/discover-skills` — all agents now discover skills natively
- **Tests rewritten**: 11 tests covering new defaults, Claude auto-detection, gitignore idempotency, `--dest-path`, `--path`, and `--list`
- **README updated**: new paths, Claude auto-detection docs, removed discover-skills section
- **Version bump**: 0.1.0 → 0.2.0

### Motivation

The agentskills.io spec has been adopted by 30+ agents (Claude Code, Codex, Cursor, VS Code/Copilot, Gemini CLI, Kiro, etc.). All of them discover `SKILL.md` files natively — the `AGENTS.md` polyfill and `discover-skills` script are no longer needed. The `.agents/skills/` directory is the cross-client interoperability convention per the spec.

Claude Code is the only major agent that doesn't scan `.agents/skills/` (it only reads `.claude/skills/`), so we auto-detect it and dual-install.

### Breaking changes

- Default install location changed from `.skills/` to `.agents/skills/` — users need to re-run upskill
- `AGENTS.md` and `.agents/discover-skills` are no longer created
- `-i` now adds `.agents/skills/` to `.gitignore` instead of `.skills/`